### PR TITLE
feature(api): Add support for project api endpoint.

### DIFF
--- a/montage/api/__init__.py
+++ b/montage/api/__init__.py
@@ -1,6 +1,7 @@
 from .document import DocumentAPI
 from .file import FileAPI
 from .policy import PolicyAPI
+from .project import ProjectAPI
 from .role import RoleAPI
 from .schema import SchemaAPI
 from .scheduler import SchedulerAPI
@@ -8,5 +9,5 @@ from .task import TaskAPI
 from .user import UserAPI
 
 
-__all__ = ('DocumentAPI', 'FileAPI', 'PolicyAPI', 'RoleAPI', 'SchemaAPI',
-    'SchedulerAPI', 'TaskAPI', 'UserAPI')
+__all__ = ('DocumentAPI', 'FileAPI', 'PolicyAPI', 'ProjectAPI', 'RoleAPI',
+    'SchemaAPI', 'SchedulerAPI', 'TaskAPI', 'UserAPI')

--- a/montage/api/project.py
+++ b/montage/api/project.py
@@ -1,0 +1,19 @@
+
+
+class ProjectAPI(object):
+    def __init__(self, client):
+        self.client = client
+
+    def get(self):
+        return self.client.request('project')
+
+    def update(self, name=None, subdomain=None):
+        payload = {}
+        if name:
+            payload['name'] = name
+        if subdomain:
+            payload['subdomain'] = subdomain
+
+        if payload:
+            return self.client.request('project',
+                method='patch', json=payload)

--- a/montage/client.py
+++ b/montage/client.py
@@ -15,14 +15,14 @@ class Client(object):
     protocol = 'https'
     timeout = 10
 
-    def __init__(self, project, token=None):
-        self.project = project
+    def __init__(self, subdomain, token=None):
+        self.subdomain = subdomain
         self.token = token
         self.requestor = APIRequestor(self)
 
     @property
     def domain(self):
-        return '{0}.{1}'.format(self.project, self.host)
+        return '{0}.{1}'.format(self.subdomain, self.host)
 
     def request(self, endpoint, method=None, **kwargs):
         kwargs.setdefault('timeout', self.timeout)
@@ -63,31 +63,35 @@ class Client(object):
         return api.FileAPI(self)
 
     @cached_property
-    def roles(self):
-        return api.RoleAPI(self)
-
-    @cached_property
-    def schemas(self):
-        return api.SchemaAPI(self)
-
-    @cached_property
-    def users(self):
-        return api.UserAPI(self)
-
-    @cached_property
     def policies(self):
         return api.PolicyAPI(self)
+
+    @cached_property
+    def project(self):
+        return api.ProjectAPI(self)
+
+    @cached_property
+    def roles(self):
+        return api.RoleAPI(self)
 
     @cached_property
     def scheduler(self):
         return api.SchedulerAPI(self)
 
     @cached_property
+    def schemas(self):
+        return api.SchemaAPI(self)
+
+    @cached_property
     def tasks(self):
         return api.TaskAPI(self)
 
+    @cached_property
+    def users(self):
+        return api.UserAPI(self)
+
 
 client = Client(
-    project=os.environ.get('MONTAGE_PROJECT'),
+    subdomain=os.environ.get('MONTAGE_SUBDOMAIN'),
     token=os.environ.get('MONTAGE_TOKEN')
 )

--- a/tests/api/test_project.py
+++ b/tests/api/test_project.py
@@ -1,0 +1,24 @@
+import responses
+from ..utils import MontageTests, make_response, PROJECT
+
+
+class ProjectAPITests(MontageTests):
+    @responses.activate
+    def test_role_detail(self):
+        endpoint = 'https://testco.hexxie.com/api/v1/project/'
+        responses.add(responses.GET, endpoint, body=make_response(PROJECT),
+            content_type='application/json')
+
+        response = self.client.project.get()
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == endpoint
+
+    @responses.activate
+    def test_role_update(self):
+        endpoint = 'https://testco.hexxie.com/api/v1/project/'
+        responses.add(responses.PATCH, endpoint, body=make_response(PROJECT),
+            content_type='application/json')
+
+        response = self.client.project.update(name='Test-Co', subdomain='test-co')
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == endpoint

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,6 +10,12 @@ def make_response(data):
     return json.dumps({'data': data})
 
 
+PROJECT = {
+    'name': 'TestCo',
+    'subdomain': 'testco',
+}
+
+
 USER = {
     'id': 1,
     'full_name': 'Joe McTest',


### PR DESCRIPTION
This also renames the `project` parameter to `subdomain` so
that `client.project` can be used for the api.
